### PR TITLE
Logs improvements

### DIFF
--- a/src/main/java/controller/model/DeleteBranchResult.java
+++ b/src/main/java/controller/model/DeleteBranchResult.java
@@ -40,4 +40,9 @@ public class DeleteBranchResult {
 		DeleteBranchResult other = (DeleteBranchResult) obj;
 		return Objects.equals(branchName, other.branchName);
 	}
+
+	@Override
+	public String toString() {
+		return "DeleteBranchResult [branchName=" + branchName + "]";
+	}
 }

--- a/src/main/java/controller/model/MergeRequestResult.java
+++ b/src/main/java/controller/model/MergeRequestResult.java
@@ -205,4 +205,9 @@ public class MergeRequestResult {
 				ucascadeState == other.ucascadeState &&
 				Objects.equals(webUrl, other.webUrl);
 	}
+
+	@Override
+	public String toString() {
+		return "MergeRequestResult [id=" + id + ", projectId=" + projectId + ", iid=" + iid + ", assigneeId=" + assigneeId + ", title=" + title + ", description=" + description + ", state=" + state + ", mergeStatus=" + mergeStatus + ", hasConflicts=" + hasConflicts + ", sourceBranch=" + sourceBranch + ", targetBranch=" + targetBranch + ", webUrl=" + webUrl + ", ucascadeState=" + ucascadeState + "]";
+	}
 }


### PR DESCRIPTION
Logs improvements:

* Logging the result is interesting to understand how the bot reacted to a merge request event (when the non blocking endpoint is used)
* In case of a concurrent MR there was no log telling why the merge is skipped.
* To String implementation was missing
