### PR TITLE
Use correct JDK version in Dockerfiles.

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile.legacy-jar
+++ b/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 


### PR DESCRIPTION
These Dockerfiles used Java 11, but `build.gradle` specifies Java 17, so the Dockerfiles failed to run the application. This fixes that, updating the Dockerfiles to use Java 17. (Also, the `-runtime` version is about 41 MB smaller.)