### PR TITLE
Assignees of the origin MR are also cascade responsible

### DIFF
--- a/_documentation/src/docs/diagrams/high-level-workflow.puml
+++ b/_documentation/src/docs/diagrams/high-level-workflow.puml
@@ -37,7 +37,7 @@ else #Pink MR #2 cannot be merged case
         ucascade->restAPI: Get preceding MR
         restAPI-->ucascade: MR
     end
-    ucascade->restAPI: Assign current MR to the MR merger found\n(the user responsible for the cascade: UserA)
+    ucascade->restAPI: Assign current MR to the merger and assignees of the MR found\n(users responsible for the cascade)
     user<-gitlab: Notification requiring manual intervention due to conflicts in MR #2
 end
 @enduml

--- a/_documentation/src/docs/diagrams/technical-workflow.puml
+++ b/_documentation/src/docs/diagrams/technical-workflow.puml
@@ -39,7 +39,7 @@ if (incoming request?) then (yes)
                             while(MR merger) is (ucascade user)
                                 :get user that merged the preceding MR;
                             endwhile (not the ucascade user)
-                            :update MR to set its assignee to the MR merger;
+                            :update MR to set its assignees to the MR assignees and merger;
                         endswitch
                     endif
                 else (no)

--- a/_documentation/src/docs/tech-docs/ucascade-blocking-response.json
+++ b/_documentation/src/docs/tech-docs/ucascade-blocking-response.json
@@ -20,7 +20,7 @@
     "id" : 38,
     "project_id" : 1,
     "mr_number" : 38,
-    "assignee_id" : 40,
+    "assignee_ids" : [ 40 ],
     "title" : "[ucascade] Auto MR: 'main/1.3.x' -> 'develop' (!25)",
     "description" : "Automatic cascade merge request: `test` !24 --> `main/1.2.x` !25 --> `main/1.3.x` --> develop",
     "state" : "opened",

--- a/src/main/java/controller/model/MergeRequestResult.java
+++ b/src/main/java/controller/model/MergeRequestResult.java
@@ -8,8 +8,10 @@
  */
 package controller.model;
 
+import java.util.List;
 import java.util.Objects;
 
+import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.models.MergeRequest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,8 +27,8 @@ public class MergeRequestResult {
 	@JsonProperty("mr_number")
 	private Long iid;
 
-	@JsonProperty("assignee_id")
-	private Long assigneeId;
+	@JsonProperty("assignee_ids")
+	private List<Long> assigneeIds;
 
 	@JsonProperty("title")
 	private String title;
@@ -67,7 +69,7 @@ public class MergeRequestResult {
 		sourceBranch = mr.getSourceBranch();
 		targetBranch = mr.getTargetBranch();
 		webUrl = mr.getWebUrl();
-		assigneeId = mr.getAssignee() == null ? null : mr.getAssignee().getId();
+		assigneeIds = mr.getAssignees() == null ? null : mr.getAssignees().stream().map(Assignee::getId).toList();
 	}
 
 	public MergeRequestResult() {
@@ -97,12 +99,12 @@ public class MergeRequestResult {
 		this.projectId = projectId;
 	}
 
-	public Long getAssigneeId() {
-		return assigneeId;
+	public List<Long> getAssigneeIds() {
+		return assigneeIds;
 	}
 
-	public void setAssigneeId(Long assigneeId) {
-		this.assigneeId = assigneeId;
+	public void setAssigneeIds(List<Long> assigneeIds) {
+		this.assigneeIds = assigneeIds;
 	}
 
 	public String getTitle() {
@@ -179,7 +181,7 @@ public class MergeRequestResult {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(assigneeId, description, hasConflicts, id, iid, detailedMergeStatus, projectId, sourceBranch, state, targetBranch, title, ucascadeState, webUrl);
+		return Objects.hash(assigneeIds, description, detailedMergeStatus, hasConflicts, id, iid, projectId, sourceBranch, state, targetBranch, title, ucascadeState, webUrl);
 	}
 
 	@Override
@@ -191,12 +193,12 @@ public class MergeRequestResult {
 		if (getClass() != obj.getClass())
 			return false;
 		MergeRequestResult other = (MergeRequestResult) obj;
-		return Objects.equals(assigneeId, other.assigneeId) &&
+		return Objects.equals(assigneeIds, other.assigneeIds) &&
 				Objects.equals(description, other.description) &&
+				Objects.equals(detailedMergeStatus, other.detailedMergeStatus) &&
 				Objects.equals(hasConflicts, other.hasConflicts) &&
 				Objects.equals(id, other.id) &&
 				Objects.equals(iid, other.iid) &&
-				Objects.equals(detailedMergeStatus, other.detailedMergeStatus) &&
 				Objects.equals(projectId, other.projectId) &&
 				Objects.equals(sourceBranch, other.sourceBranch) &&
 				Objects.equals(state, other.state) &&
@@ -208,6 +210,7 @@ public class MergeRequestResult {
 
 	@Override
 	public String toString() {
-		return "MergeRequestResult [id=" + id + ", projectId=" + projectId + ", iid=" + iid + ", assigneeId=" + assigneeId + ", title=" + title + ", description=" + description + ", state=" + state + ", mergeStatus=" + detailedMergeStatus + ", hasConflicts=" + hasConflicts + ", sourceBranch=" + sourceBranch + ", targetBranch=" + targetBranch + ", webUrl=" + webUrl + ", ucascadeState=" + ucascadeState + "]";
+		return "MergeRequestResult [id=" + id + ", projectId=" + projectId + ", iid=" + iid + ", assigneeIds=" + assigneeIds + ", title=" + title + ", description=" + description + ", state=" + state + ", detailedMergeStatus=" + detailedMergeStatus + ", hasConflicts=" + hasConflicts + ", sourceBranch=" + sourceBranch + ", targetBranch=" + targetBranch + ", webUrl=" + webUrl + ", ucascadeState=" + ucascadeState + "]";
 	}
+
 }

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -406,10 +406,7 @@ public class GitLabService {
 		final Long project = mr.getProjectId();
 		List<Long> cascadeResponsibleIds = getCascadeResponsibleIds(gitlabEventUUID, project, getPrevMergeRequestNumber(mr.getSourceBranch()));
 		if (cascadeResponsibleIds != null) {
-			Log.infof("GitlabEvent: '%s' | Assigning MR '!%d' to cascade responsible(s) with id(s): '%s'",
-					gitlabEventUUID,
-					mrNumber,
-					cascadeResponsibleIds.stream().map(String::valueOf).collect(Collectors.joining("', '")));
+			Log.infof("GitlabEvent: '%s' | Assigning MR '!%d' to cascade responsible(s) with id(s): '%s'", gitlabEventUUID, mrNumber, cascadeResponsibleIds);
 			try {
 				MergeRequestParams mrParams = new MergeRequestParams();
 				mrParams.withAssigneeIds(cascadeResponsibleIds);

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -1,6 +1,12 @@
 package service;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -16,7 +22,11 @@ import org.gitlab4j.api.Constants.MergeRequestState;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.MergeRequestApi;
-import org.gitlab4j.api.models.*;
+import org.gitlab4j.api.models.AcceptMergeRequestParams;
+import org.gitlab4j.api.models.Assignee;
+import org.gitlab4j.api.models.Branch;
+import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.MergeRequestParams;
 
 import controller.model.CascadeResult;
 import controller.model.DeleteBranchResult;

--- a/src/test/java/com/unblu/ucascade/UcascadeTest.java
+++ b/src/test/java/com/unblu/ucascade/UcascadeTest.java
@@ -395,7 +395,7 @@ class UcascadeTest {
 				.body("created_auto_mr.detailed_merge_status", equalTo("broken_status"))
 				.body("created_auto_mr.has_conflicts", equalTo(true))
 				.body("created_auto_mr.ucascade_state", equalTo(MergeRequestUcascadeState.NOT_MERGED_CONFLICTS.name()))
-				.body("created_auto_mr.assignee_id", equalTo(987)) // the merge_user of the previous MR
+				.body("created_auto_mr.assignee_ids", equalTo(List.of(987, 988))) // the merge_user + assignee of the previous MR
 				.body("existing_branch_deleted", nullValue());
 
 		verifyRequests(12);
@@ -444,7 +444,7 @@ class UcascadeTest {
 				.body("created_auto_mr.detailed_merge_status", equalTo("policies_denied"))
 				.body("created_auto_mr.has_conflicts", equalTo(false))
 				.body("created_auto_mr.ucascade_state", equalTo(MergeRequestUcascadeState.NOT_MERGED_UNKNOWN_REASON.name()))
-				.body("created_auto_mr.assignee_id", equalTo(987)) // the merge_user of the previous MR
+				.body("created_auto_mr.assignee_ids", equalTo(List.of(987, 988))) // the merge_user + assignee of the previous MR
 				.body("existing_branch_deleted", nullValue());
 
 		verifyRequests(12);

--- a/src/test/java/com/unblu/ucascade/util/JsonUtilsTest.java
+++ b/src/test/java/com/unblu/ucascade/util/JsonUtilsTest.java
@@ -3,6 +3,7 @@ package com.unblu.ucascade.util;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.gitlab4j.api.Constants.MergeRequestState;
 import org.gitlab4j.api.utils.JacksonJson;
@@ -126,7 +127,7 @@ class JsonUtilsTest {
 		previousAutoMrMerged.setUcascadeState(MergeRequestUcascadeState.MERGED);
 
 		MergeRequestResult createdAutoMr = new MergeRequestResult();
-		createdAutoMr.setAssigneeId(40L);
+		createdAutoMr.setAssigneeIds(List.of(40L));
 		createdAutoMr.setId(38L);
 		createdAutoMr.setIid(38L);
 		createdAutoMr.setProjectId(1L);

--- a/src/test/resources/gitlab_template_json/api/getMRResponse.json
+++ b/src/test/resources/gitlab_template_json/api/getMRResponse.json
@@ -39,8 +39,22 @@
     "avatar_url" : "https://www.gravatar.com/avatar/e633807329b048c67a0431d8df47057e?s=80&d=identicon",
     "web_url" : "http://localhost:9080/root"
   },
-  "assignees" : [ ],
-  "assignee" : null,
+  "assignees" : [{
+    "id" : 988,
+    "name" : "John Doe2",
+    "username" : "user2",
+    "state" : "active",
+    "avatar_url" : "http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon",
+    "web_url" : "http://localhost/user2"
+  }],
+  "assignee" : {
+    "id" : 988,
+    "name" : "John Doe2",
+    "username" : "user2",
+    "state" : "active",
+    "avatar_url" : "http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon",
+    "web_url" : "http://localhost/user2"
+  },
   "reviewers" : [ ],
   "source_project_id" : 1,
   "target_project_id" : 1,

--- a/src/test/resources/gitlab_template_json/api/updateMRResponse.json
+++ b/src/test/resources/gitlab_template_json/api/updateMRResponse.json
@@ -25,7 +25,21 @@
     "avatar_url" : "https://www.gravatar.com/avatar/e633807329b048c67a0431d8df47057e?s=80&d=identicon",
     "web_url" : "http://localhost:9080/root"
   },
-  "assignees" : [ ],
+  "assignees" : [{
+    "id" : 987,
+    "name" : "John Doe1",
+    "username" : "user1",
+    "state" : "active",
+    "avatar_url" : "http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon",
+    "web_url" : "http://localhost/user1"
+  },{
+    "id" : 988,
+    "name" : "John Doe2",
+    "username" : "user2",
+    "state" : "active",
+    "avatar_url" : "http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon",
+    "web_url" : "http://localhost/user2"
+  }],
   "assignee" : {
   	"id" : 987,
     "name" : "John Doe1",


### PR DESCRIPTION
Fixes #13 

The assignees of the MR that originated the cascade are now also considered cascade responsible, in addition to the user that merged it.
