### PR TITLE
Wait for approved MRs to leave the not_approved state

### DIFF
--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -473,12 +473,8 @@ public class GitLabService {
 	}
 
 	public static boolean isMrReady(String mrStatus, boolean approverExists) {
-		if (mrStatus.matches("unchecked|checking|preparing") ||
-				(approverExists && mrStatus.matches("not_approved"))) {
-			return false;
-		} else {
-			return true;
-		}
+		return !(mrStatus.matches("unchecked|checking|preparing") ||
+				(approverExists && mrStatus.matches("not_approved")));
 	}
 
 	private Branch getBranch(String gitlabEventUUID, Long project, String branchName) {

--- a/src/test/java/com/unblu/ucascade/UcascadeTest.java
+++ b/src/test/java/com/unblu/ucascade/UcascadeTest.java
@@ -835,6 +835,20 @@ class UcascadeTest {
 		verifyRequests(0);
 	}
 
+	@Test
+	void testMrReady() {
+		Assertions.assertFalse(GitLabService.isMrReady("not_approved", true));
+		Assertions.assertFalse(GitLabService.isMrReady("unchecked", false));
+		Assertions.assertFalse(GitLabService.isMrReady("unchecked", true));
+		Assertions.assertFalse(GitLabService.isMrReady("checking", false));
+		Assertions.assertFalse(GitLabService.isMrReady("checking", true));
+		Assertions.assertFalse(GitLabService.isMrReady("preparing", false));
+		Assertions.assertFalse(GitLabService.isMrReady("preparing", true));
+		Assertions.assertTrue(GitLabService.isMrReady("not_approved", false));
+		Assertions.assertTrue(GitLabService.isMrReady("everything_else", false));
+		Assertions.assertTrue(GitLabService.isMrReady("everything_else", true));
+	}
+
 	private void verifyRequests(int expectedRequestNumber) throws InterruptedException {
 		List<ServeEvent> allServeEvents = waitForRequests(expectedRequestNumber);
 


### PR DESCRIPTION
The status of a Merge-Request may not be updated immediately after it has been approved. For this reason, trying to merge a MR right after it has been approved, may not be possible.

With this MR, we expect this scenario (MR is approved but not reported as such), and we wait for MR to report the correct status.