### PR TITLE
retry merge if the MR status is status_checks_must_pass

### DIFF
--- a/_documentation/src/docs/diagrams/technical-workflow.puml
+++ b/_documentation/src/docs/diagrams/technical-workflow.puml
@@ -28,7 +28,7 @@ if (incoming request?) then (yes)
                     if (countDown == 0) then (yes) 
                         :error;
                     else (no)
-                        switch(Is MRStatus == mergeable|ci_still_running|ci_must_pass?)
+                        switch(Is MRStatus == mergeable|ci_still_running|ci_must_pass|status_checks_must_pass?)
                         case (yes)
                             if (MR has pipeline(s)?) then (yes)
                                 :merge when pipeline succeeds;

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -364,7 +364,7 @@ public class GitLabService {
 
 		MergeRequestApi mrApi = gitlab.getMergeRequestApi();
 		MergeRequestUcascadeState state = MergeRequestUcascadeState.NOT_MERGED_UNKNOWN_REASON;
-		if (mergeStatus.matches("mergeable|ci_still_running|ci_must_pass")) {
+		if (mergeStatus.matches("mergeable|ci_still_running|ci_must_pass|status_checks_must_pass")) {
 			// Prepare merge:
 			String sourceBranch = mr.getSourceBranch();
 			String sourceBranchPretty = removeMrPrefixPattern(sourceBranch);


### PR DESCRIPTION
we should additionally expect the `status_checks_must_pass` as MR status that can be re-tried