### PR TITLE
Add support for "approvals_syncing" MR status

### DIFF
--- a/_documentation/src/docs/diagrams/technical-workflow.puml
+++ b/_documentation/src/docs/diagrams/technical-workflow.puml
@@ -19,7 +19,7 @@ if (incoming request?) then (yes)
                         Timeout to avoid the possibility
                         of getting stuck in the loop forever
                     end note
-                    while(MRStatus == unchecked|checking and countdown > 0?) is (yes)
+                    while(MRStatus == unchecked|checking|preparing|approvals_syncing and countdown > 0?) is (yes)
                         #SkyBlue:decrement countDown by 1;
                         :sleep 1s;
                         note right: Wait for Gitlab to prepare MR

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -522,7 +522,7 @@ public class GitLabService {
 	}
 
 	public static boolean isMrReady(String mrStatus, boolean approverExists, Boolean hasConflicts) {
-		return !(mrStatus.matches("unchecked|checking|preparing") ||
+		return !(mrStatus.matches("unchecked|checking|preparing|approvals_syncing") ||
 				(approverExists && mrStatus.matches("not_approved")) ||
 				!(hasConflicts != null && hasConflicts) && mrStatus.matches("broken_status"));
 	}

--- a/src/test/java/com/unblu/ucascade/UcascadeTest.java
+++ b/src/test/java/com/unblu/ucascade/UcascadeTest.java
@@ -844,6 +844,8 @@ class UcascadeTest {
 		Assertions.assertFalse(GitLabService.isMrReady("checking", true, false));
 		Assertions.assertFalse(GitLabService.isMrReady("preparing", false, false));
 		Assertions.assertFalse(GitLabService.isMrReady("preparing", true, false));
+		Assertions.assertFalse(GitLabService.isMrReady("approvals_syncing", false, false));
+		Assertions.assertFalse(GitLabService.isMrReady("approvals_syncing", true, false));
 		Assertions.assertFalse(GitLabService.isMrReady("broken_status", true, false));
 		Assertions.assertFalse(GitLabService.isMrReady("broken_status", false, false));
 		Assertions.assertFalse(GitLabService.isMrReady("broken_status", false, null));


### PR DESCRIPTION
Fixes #31

Retrying on all "unknown" MR status is also not perfect: 
* sometimes we have to consider the `broken_status` as valid. See https://github.com/unblu/ucascade/issues/21
* we know that some status will lead to a "mergeable" status, so we try merge already. For the moment, the list of "mergeable" MR status is: `mergeable`|`ci_still_running`|`ci_must_pass`|`status_checks_must_pass`, documented in 
https://unblu.github.io/ucascade/tech-docs/30_technical-documentation.html#_created_auto_mr 

With all the sub-cases I went with just adding support for the new status `approvals_syncing`, but let me know your thoughts.