### PR TITLE
Support FF merge strategy

### DIFF
--- a/_documentation/src/docs/tech-docs/20_endpoints.adoc
+++ b/_documentation/src/docs/tech-docs/20_endpoints.adoc
@@ -41,7 +41,11 @@ Since GitLab keeps the response obtained when delivering a webhook event and dis
 
 === Replay endpoint
 
-An additional endpoint is available to trigger the process using some simplified input compared to the merge-request event body sent by the GitLab Webhook API.
+An additional endpoint is available to trigger the process using some simplified input compared to the merge-request event body sent by the GitLab Webhook API. In this simplified input, the `start_commit_sha` may correspond to two different things in original merge-request event:
+
+* To the `merge_commit_sha`, in case the merge created a merge commit
+* To the `last_commit.id` in case the fast-forward merge strategy is used (no merge commit)
+
 
 `POST <server url>/ucascade/replay`
 

--- a/_documentation/src/docs/tech-docs/replay.json
+++ b/_documentation/src/docs/tech-docs/replay.json
@@ -5,7 +5,7 @@
   "source_branch" : "feature/1.3.x/some-change",
   "target_branch" : "main/1.3.x",
   "mr_state" : "merged",
-  "merge_commit_sha" : "0c6f9d312b924bff313f60db2f269b5f4901cd95",
+  "start_commit_sha" : "0c6f9d312b924bff313f60db2f269b5f4901cd95",
   "mr_action" : "merge",
   "gitlab_event_uuid" : "replay-394720"
 }

--- a/src/main/java/controller/model/MergeRequestSimple.java
+++ b/src/main/java/controller/model/MergeRequestSimple.java
@@ -18,8 +18,8 @@ public class MergeRequestSimple {
 	private String targetBranch;
 	@JsonProperty("mr_state")
 	private String mrState;
-	@JsonProperty("merge_commit_sha")
-	private String mergeCommitSha;
+	@JsonProperty("start_commit_sha")
+	private String startCommitSha;
 	@JsonProperty("mr_action")
 	private String mrAction;
 
@@ -30,14 +30,14 @@ public class MergeRequestSimple {
 		super();
 	}
 
-	public MergeRequestSimple(Long projectId, Long mrNumber, Long userId, String sourceBranch, String targetBranch, String mrState, String mergeCommitSha, String mrAction, String gitlabEventUUID) {
+	public MergeRequestSimple(Long projectId, Long mrNumber, Long userId, String sourceBranch, String targetBranch, String mrState, String startCommitSha, String mrAction, String gitlabEventUUID) {
 		this.projectId = projectId;
 		this.mrNumber = mrNumber;
 		this.userId = userId;
 		this.sourceBranch = sourceBranch;
 		this.targetBranch = targetBranch;
 		this.mrState = mrState;
-		this.mergeCommitSha = mergeCommitSha;
+		this.startCommitSha = startCommitSha;
 		this.gitlabEventUUID = gitlabEventUUID;
 		this.mrAction = mrAction;
 	}
@@ -90,12 +90,12 @@ public class MergeRequestSimple {
 		this.mrState = mrState;
 	}
 
-	public String getMergeCommitSha() {
-		return mergeCommitSha;
+	public String getStartCommitSha() {
+		return startCommitSha;
 	}
 
-	public void setMergeCommitSha(String mergeCommitSha) {
-		this.mergeCommitSha = mergeCommitSha;
+	public void setStartCommitSha(String startCommitSha) {
+		this.startCommitSha = startCommitSha;
 	}
 
 	public String getMrAction() {
@@ -116,7 +116,7 @@ public class MergeRequestSimple {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(gitlabEventUUID, mergeCommitSha, mrAction, mrNumber, mrState, projectId, sourceBranch, targetBranch, userId);
+		return Objects.hash(gitlabEventUUID, startCommitSha, mrAction, mrNumber, mrState, projectId, sourceBranch, targetBranch, userId);
 	}
 
 	@Override
@@ -129,7 +129,7 @@ public class MergeRequestSimple {
 			return false;
 		MergeRequestSimple other = (MergeRequestSimple) obj;
 		return Objects.equals(gitlabEventUUID, other.gitlabEventUUID) &&
-				Objects.equals(mergeCommitSha, other.mergeCommitSha) &&
+				Objects.equals(startCommitSha, other.startCommitSha) &&
 				Objects.equals(mrAction, other.mrAction) &&
 				Objects.equals(mrNumber, other.mrNumber) &&
 				Objects.equals(mrState, other.mrState) &&
@@ -141,7 +141,7 @@ public class MergeRequestSimple {
 
 	@Override
 	public String toString() {
-		return "MergeRequestSimple [projectId=" + projectId + ", mrNumber=" + mrNumber + ", userId=" + userId + ", sourceBranch=" + sourceBranch + ", targetBranch=" + targetBranch + ", mrState=" + mrState + ", mergeCommitSha=" + mergeCommitSha + ", mrAction=" + mrAction + ", gitlabEventUUID=" + gitlabEventUUID + "]";
+		return "MergeRequestSimple [projectId=" + projectId + ", mrNumber=" + mrNumber + ", userId=" + userId + ", sourceBranch=" + sourceBranch + ", targetBranch=" + targetBranch + ", mrState=" + mrState + ", startCommitSha=" + startCommitSha + ", mrAction=" + mrAction + ", gitlabEventUUID=" + gitlabEventUUID + "]";
 	}
 
 }

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -119,7 +119,7 @@ public class GitLabService {
 		String sourceBranch = mrEvent.getSourceBranch();
 		String targetBranch = mrEvent.getTargetBranch();
 		Long mrNumber = mrEvent.getMrNumber();
-		String mergeSha = mrEvent.getMergeCommitSha();
+		String mergeSha = mrEvent.getStartCommitSha();
 		String prevSourceBranch = removeMrPrefixPattern(sourceBranch);
 
 		Log.infof("GitlabEvent: '%s' | Merge MR Event. Project: '%d', User: '%d', Target: '%s', MergeRequestNumber: '%d'",

--- a/src/main/java/util/JsonUtils.java
+++ b/src/main/java/util/JsonUtils.java
@@ -49,7 +49,7 @@ public class JsonUtils {
 		result.setSourceBranch(objectAttributes.getSourceBranch());
 		result.setTargetBranch(objectAttributes.getTargetBranch());
 		result.setMrNumber(objectAttributes.getIid());
-		result.setMergeCommitSha(objectAttributes.getMergeCommitSha());
+		result.setStartCommitSha(objectAttributes.getMergeCommitSha() != null ? objectAttributes.getMergeCommitSha() : objectAttributes.getLastCommit().getId());
 		result.setMrState(objectAttributes.getState());
 		result.setMrAction(objectAttributes.getAction());
 

--- a/src/test/java/com/unblu/ucascade/util/GitlabMockUtil.java
+++ b/src/test/java/com/unblu/ucascade/util/GitlabMockUtil.java
@@ -32,7 +32,7 @@ public class GitlabMockUtil {
 		// REST API
 		CREATE_BRANCH, CREATE_MR, ACCEPT_MR, APPROVE_MR, GET_APPROVALS, UPDATE_MR, GET_OPEN_MRS, GET_MR, GET_BRANCH, GET_FILE, LIST_MR_PIPELINES, COMPARE_DIFF_BRANCHES, COMPARE_NO_DIFF_BRANCHES, GET_USER,
 		// Webhook
-		EVENT_MR_MERGED;
+		EVENT_MR_MERGED, EVENT_MR_FF_MERGED;
 	}
 
 	private static final EnumMap<GitlabAction, String> jsonTemplatesLocation = initJsonTemplatesLocationMap();
@@ -73,6 +73,7 @@ public class GitlabMockUtil {
 		templates.put(GitlabAction.COMPARE_NO_DIFF_BRANCHES, "/gitlab_template_json/api/compareNoDiffBranchesResponse.json");
 		templates.put(GitlabAction.GET_USER, "/gitlab_template_json/api/getUserResponse.json");
 		templates.put(GitlabAction.EVENT_MR_MERGED, "/gitlab_template_json/webhook/mergedMREvent.json");
+		templates.put(GitlabAction.EVENT_MR_FF_MERGED, "/gitlab_template_json/webhook/mergedFFMREvent.json");
 
 		return templates;
 	}

--- a/src/test/resources/gitlab_template_json/webhook/mergedFFMREvent.json
+++ b/src/test/resources/gitlab_template_json/webhook/mergedFFMREvent.json
@@ -1,0 +1,137 @@
+{
+  "object_kind" : "merge_request",
+  "event_type" : "merge_request",
+  "user" : {
+    "id" : 1,
+    "name" : "Administrator",
+    "username" : "root",
+    "avatar_url" : "https://www.gravatar.com/avatar/e633807329b048c67a0431d8df47057e?s=80&d=identicon",
+    "email" : "[REDACTED]"
+  },
+  "project" : {
+    "id" : 1,
+    "name" : "test_project",
+    "description" : null,
+    "web_url" : "http://localhost:9080/root/test_project",
+    "avatar_url" : null,
+    "git_ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+    "git_http_url" : "http://localhost:9080/root/test_project.git",
+    "namespace" : "Administrator",
+    "visibility_level" : 20,
+    "path_with_namespace" : "root/test_project",
+    "default_branch" : "main",
+    "ci_config_path" : null,
+    "homepage" : "http://localhost:9080/root/test_project",
+    "url" : "ssh://git@localhost:9022/root/test_project.git",
+    "ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+    "http_url" : "http://localhost:9080/root/test_project.git"
+  },
+  "object_attributes" : {
+    "assignee_id" : null,
+    "author_id" : 1,
+    "created_at" : "2022-09-04 16:44:58 UTC",
+    "description" : "A dummy pr",
+    "head_pipeline_id" : null,
+    "id" : 1,
+    "iid" : 100,
+    "last_edited_at" : null,
+    "last_edited_by_id" : null,
+    "merge_commit_sha" : null,
+    "merge_error" : null,
+    "merge_params" : {
+      "force_remove_source_branch" : true
+    },
+    "merge_status" : "can_be_merged",
+    "detailed_merge_status" : "mergeable",
+    "merge_user_id" : null,
+    "merge_when_pipeline_succeeds" : false,
+    "milestone_id" : null,
+    "source_branch" : "some-feature",
+    "source_project_id" : 1,
+    "state_id" : 1,
+    "target_branch" : "release/6.x.x",
+    "target_project_id" : 1,
+    "time_estimate" : 0,
+    "title" : "Some feature",
+    "updated_at" : "2022-09-04 16:44:58 UTC",
+    "updated_by_id" : null,
+    "url" : "http://localhost:9080/root/test_project/-/merge_requests/100",
+    "source" : {
+      "id" : 1,
+      "name" : "test_project",
+      "description" : null,
+      "web_url" : "http://localhost:9080/root/test_project",
+      "avatar_url" : null,
+      "git_ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+      "git_http_url" : "http://localhost:9080/root/test_project.git",
+      "namespace" : "Administrator",
+      "visibility_level" : 20,
+      "path_with_namespace" : "root/test_project",
+      "default_branch" : "main",
+      "ci_config_path" : null,
+      "homepage" : "http://localhost:9080/root/test_project",
+      "url" : "ssh://git@localhost:9022/root/test_project.git",
+      "ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+      "http_url" : "http://localhost:9080/root/test_project.git"
+    },
+    "target" : {
+      "id" : 1,
+      "name" : "test_project",
+      "description" : null,
+      "web_url" : "http://localhost:9080/root/test_project",
+      "avatar_url" : null,
+      "git_ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+      "git_http_url" : "http://localhost:9080/root/test_project.git",
+      "namespace" : "Administrator",
+      "visibility_level" : 20,
+      "path_with_namespace" : "root/test_project",
+      "default_branch" : "main",
+      "ci_config_path" : null,
+      "homepage" : "http://localhost:9080/root/test_project",
+      "url" : "ssh://git@localhost:9022/root/test_project.git",
+      "ssh_url" : "ssh://git@localhost:9022/root/test_project.git",
+      "http_url" : "http://localhost:9080/root/test_project.git"
+    },
+    "last_commit" : {
+      "id" : "e819d39ed37c6d4b8e700b9e7f34c74c099c163b",
+      "message" : "My feature",
+      "title" : "My feature",
+      "timestamp" : "2022-09-04T16:44:58+00:00",
+      "url" : "http://localhost:9080/root/test_project/-/commit/3f46808aa9df132cb84b411e7c605642f6289005",
+      "author" : {
+        "name" : "Administrator",
+        "email" : "root@local"
+      }
+    },
+    "work_in_progress" : false,
+    "total_time_spent" : 0,
+    "time_change" : 0,
+    "human_total_time_spent" : null,
+    "human_time_change" : null,
+    "human_time_estimate" : null,
+    "assignee_ids" : [ ],
+    "reviewer_ids" : [ ],
+    "labels" : [ ],
+    "state" : "merged",
+    "blocking_discussions_resolved" : true,
+    "first_contribution" : false,
+    "action" : "merge"
+  },
+  "labels" : [ ],
+  "changes" : {
+    "state_id" : {
+      "previous" : 4,
+      "current" : 3
+    },
+    "updated_at" : {
+      "previous" : "2022-09-04 16:44:58 UTC",
+      "current" : "2022-09-04 16:44:58 UTC"
+    }
+  },
+  "repository" : {
+    "name" : "test_project",
+    "url" : "ssh://git@localhost:9022/root/test_project.git",
+    "description" : null,
+    "homepage" : "http://localhost:9080/root/test_project"
+  }
+}


### PR DESCRIPTION
When the fast-forward merge strategy is used, there is no merge commit SHA. In this case, we use the last commit SHA as ref 

Fixes #34