### PR TITLE
Use the 'io.quarkus:quarkus-info' extension

### DIFF
--- a/_documentation/src/docs/tech-docs/20_endpoints.adoc
+++ b/_documentation/src/docs/tech-docs/20_endpoints.adoc
@@ -67,3 +67,11 @@ The application provides standard probes:
 * `<server url>/q/health/live`: The application is up and running (liveness).
 * `<server url>/q/health/ready`: The application is ready to serve requests (readiness).
 * `<server url>/q/health`: Accumulating all health check procedures in the application.
+
+=== Info endpoint
+
+The application provides some information about the current version:
+
+* `<server url>/q/info`
+
+This can be turned off with the quarkus configuration property `quarkus.info.enabled` set to `false`.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-info'
     implementation 'io.quarkus:quarkus-reactive-routes'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-container-image-jib'
@@ -55,37 +56,4 @@ spotless {
     // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter
     eclipse('4.21.0').configFile('.settings/org.eclipse.jdt.core.prefs')
   }
-}
-
-def genOutputDir = file("$buildDir/generated/main-resources")
-
-def generateMainResourcesTask = tasks.register('generateMainResources') {
-    def generatedFile = new File(genOutputDir, "application.properties")
-    outputs.file(generatedFile)
-
-    doLast {
-        generatedFile.text = """
-gitlab.host=https://gitlab.com
-quarkus.container-image.tag=latest
-
-build.commit=${grgit.head().abbreviatedId}
-build.timestamp=${java.time.Instant.now().toString()}
-
-quarkus.index-dependency.gitlab4j-api.group-id=org.gitlab4j
-quarkus.index-dependency.gitlab4j-api.artifact-id=gitlab4j-api
-
-quarkus.index-dependency.gitlab4j-models.group-id=org.gitlab4j
-quarkus.index-dependency.gitlab4j-models.artifact-id=gitlab4j-models
-
-%dev.quarkus.log.console.google=false
-%test.quarkus.log.console.google=false
-"""
-    }
-}
-
-sourceSets.main.resources.srcDir(genOutputDir)
-model {
-    tasks.processResources {
-        dependsOn generateMainResourcesTask
-    }
 }

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -35,6 +35,8 @@ import controller.model.DeleteBranchResult;
 import controller.model.MergeRequestResult;
 import controller.model.MergeRequestSimple;
 import controller.model.MergeRequestUcascadeState;
+import io.quarkus.info.BuildInfo;
+import io.quarkus.info.GitInfo;
 import io.quarkus.logging.Log;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Blocking;
@@ -58,11 +60,11 @@ public class GitLabService {
 	@ConfigProperty(name = "gitlab.api.token.approver")
 	Optional<String> apiTokenApprover;
 
-	@ConfigProperty(name = "build.commit", defaultValue = "n/a")
-	String buildCommit;
+	@Inject
+	GitInfo gitInfo;
 
-	@ConfigProperty(name = "build.timestamp", defaultValue = "n/a")
-	String buildTimestamp;
+	@Inject
+	BuildInfo buildInfo;
 
 	private static final String UCASCADE_CONFIGURATION_FILE = "ucascade.json";
 	private static final String UCASCADE_TAG = "[ucascade]";
@@ -108,8 +110,8 @@ public class GitLabService {
 	public CascadeResult createResult(String gitlabEventUUID) {
 		CascadeResult result = new CascadeResult();
 		result.setGitlabEventUUID(gitlabEventUUID);
-		result.setBuildCommit(buildCommit);
-		result.setBuildTimestamp(buildTimestamp);
+		result.setBuildCommit(gitInfo.latestCommitId().substring(7));
+		result.setBuildTimestamp(buildInfo.time().toString());
 		return result;
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+gitlab.host=https://gitlab.com
+quarkus.container-image.tag=latest
+
+quarkus.index-dependency.gitlab4j-api.group-id=org.gitlab4j
+quarkus.index-dependency.gitlab4j-api.artifact-id=gitlab4j-api
+
+quarkus.index-dependency.gitlab4j-models.group-id=org.gitlab4j
+quarkus.index-dependency.gitlab4j-models.artifact-id=gitlab4j-models
+
+quarkus.info.git.enabled=true
+quarkus.info.git.mode=standard
+quarkus.info.build.enabled=true
+quarkus.info.os.enabled=false
+quarkus.info.java.enabled=false
+
+%dev.quarkus.log.console.google=false
+%test.quarkus.log.console.google=false

--- a/src/test/java/com/unblu/ucascade/UcascadeTest.java
+++ b/src/test/java/com/unblu/ucascade/UcascadeTest.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -46,6 +47,8 @@ import com.unblu.ucascade.util.GitlabMockUtil.GitlabAction;
 
 import controller.model.MergeRequestSimple;
 import controller.model.MergeRequestUcascadeState;
+import io.quarkus.info.BuildInfo;
+import io.quarkus.info.GitInfo;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import service.GitLabService;
@@ -66,6 +69,12 @@ class UcascadeTest {
 	Optional<String> apiTokenApprover;
 
 	String branchModelContent;
+
+	@Inject
+	GitInfo gitInfo;
+
+	@Inject
+	BuildInfo buildInfo;
 
 	@BeforeEach
 	void init() throws IOException {
@@ -88,8 +97,8 @@ class UcascadeTest {
 				.body(startsWith("{\n"))
 				.body(endsWith("\n}"))
 				.body("gitlab_event_uuid", equalTo(GitlabMockUtil.GITLAB_EVENT_UUID))
-				.body("build_commit", equalTo("6af21ad"))
-				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"));
+				.body("build_commit", equalTo(expectedBuildCommitValue()))
+				.body("build_timestamp", equalTo(expectedBuildTimestampValue()));
 
 		verifyRequests(13);
 	}
@@ -116,8 +125,8 @@ class UcascadeTest {
 				.body(startsWith("{\n"))
 				.body(endsWith("\n}"))
 				.body("gitlab_event_uuid", equalTo(GitlabMockUtil.GITLAB_EVENT_UUID))
-				.body("build_commit", equalTo("6af21ad"))
-				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"))
+				.body("build_commit", equalTo(expectedBuildCommitValue()))
+				.body("build_timestamp", equalTo(expectedBuildTimestampValue()))
 				.body("created_auto_mr.title", equalTo(expectedTitle))
 				.body("created_auto_mr.description", equalTo(expectedDescription))
 				.body("created_auto_mr.mr_number", equalTo(mrNumber.intValue()))
@@ -151,8 +160,8 @@ class UcascadeTest {
 				.body(startsWith("{\n"))
 				.body(endsWith("\n}"))
 				.body("gitlab_event_uuid", equalTo(GitlabMockUtil.GITLAB_EVENT_UUID))
-				.body("build_commit", equalTo("6af21ad"))
-				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"))
+				.body("build_commit", equalTo(expectedBuildCommitValue()))
+				.body("build_timestamp", equalTo(expectedBuildTimestampValue()))
 				.body("created_auto_mr.title", equalTo(expectedTitle))
 				.body("created_auto_mr.description", equalTo(expectedDescription))
 				.body("created_auto_mr.mr_number", equalTo(mrNumber.intValue()))
@@ -803,8 +812,8 @@ class UcascadeTest {
 				.body(startsWith("{\n"))
 				.body(endsWith("\n}"))
 				.body("gitlab_event_uuid", nullValue())
-				.body("build_commit", equalTo("6af21ad"))
-				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"))
+				.body("build_commit", equalTo(expectedBuildCommitValue()))
+				.body("build_timestamp", equalTo(expectedBuildTimestampValue()))
 				.body("error", startsWith("Could not resolve subtype of"));
 
 		verifyRequests(0);
@@ -828,8 +837,8 @@ class UcascadeTest {
 				.body(startsWith("{\n"))
 				.body(endsWith("\n}"))
 				.body("gitlab_event_uuid", equalTo("test-1289369"))
-				.body("build_commit", equalTo("6af21ad"))
-				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"))
+				.body("build_commit", equalTo(expectedBuildCommitValue()))
+				.body("build_timestamp", equalTo(expectedBuildTimestampValue()))
 				.body("error", equalTo("Invalid path: /foo"));
 
 		verifyRequests(0);
@@ -926,6 +935,14 @@ class UcascadeTest {
 
 	private boolean isGetUserStub(StubMapping stub) {
 		return Objects.equals("/api/v4/user", stub.getRequest().getUrlPath());
+	}
+
+	private String expectedBuildCommitValue() {
+		return gitInfo.latestCommitId().substring(7);
+	}
+
+	private String expectedBuildTimestampValue() {
+		return buildInfo.time().toString();
 	}
 
 	private void setupCreateBranchStub(Long projectId, String branch, String ref, Map<String, Object> customProperties) {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,2 @@
-build.timestamp=2022-01-01T07:21:58.378413Z
-build.commit=6af21ad
 gitlab.api.token=token_used_in_unit_tests_1234
 gitlab.api.token.approver=approver_token_used_in_unit_tests_1234


### PR DESCRIPTION
Use the `io.quarkus:quarkus-info` extension instead of the custom configuration properties `build.timestamp` and `build.commit`.