### PR TITLE
Update "gitlab4j-api" to version "6.0.0-rc.8"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-container-image-jib'
     implementation 'io.quarkus:quarkus-arc'
-    implementation 'org.gitlab4j:gitlab4j-api:6.0.0-rc.7'
+    implementation 'org.gitlab4j:gitlab4j-api:6.0.0-rc.8'
     implementation 'eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:6.0.0'
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,6 @@
 gitlab.host=https://gitlab.com
 quarkus.container-image.tag=latest
 
-quarkus.index-dependency.gitlab4j-api.group-id=org.gitlab4j
-quarkus.index-dependency.gitlab4j-api.artifact-id=gitlab4j-api
-
-quarkus.index-dependency.gitlab4j-models.group-id=org.gitlab4j
-quarkus.index-dependency.gitlab4j-models.artifact-id=gitlab4j-models
-
 quarkus.info.git.enabled=true
 quarkus.info.git.mode=standard
 quarkus.info.build.enabled=true


### PR DESCRIPTION
Update gitlab4j client to [6.0.0-rc.8](https://github.com/gitlab4j/gitlab4j-api/releases/tag/6.0.0-rc.8)

Remove the need of computing the jandex index in ucascade since this is already part of the jar.