### PR TITLE
Add a 5 seconds sleep period after the temporary branch is created

### DIFF
--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -218,6 +218,7 @@ public class GitLabService {
 			if (haveDiff(gitlabEventUUID, projectId, mergeSha, nextMainBranch)) {
 				String tmpBranchName = "mr" + mrNumber + "_" + sourceBranch;
 				createBranch(gitlabEventUUID, projectId, tmpBranchName, mergeSha);
+				sleepSeconds(5); // give Gitlab time to recognize newly created branch
 				MergeRequestResult mrResult = merge(gitlabEventUUID, projectId, sourceBranch, mrNumber, tmpBranchName, nextMainBranch);
 				result.setCreatedAutoMr(mrResult);
 			} else {


### PR DESCRIPTION
This is an attempt to avoid the occasional "restored source branch" event that shows in the subsequently created merge-request.

Fixes #37