### PR TITLE
Add Protected Branch Merge Strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-arc'
     implementation 'org.gitlab4j:gitlab4j-api:6.0.0-rc.8'
     implementation 'eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:6.0.0'
+    implementation 'se.sawano.java:alphanumeric-comparator:2.0.0'
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'

--- a/src/main/java/enums/MergeStrategy.java
+++ b/src/main/java/enums/MergeStrategy.java
@@ -1,0 +1,7 @@
+package enums;
+
+public enum MergeStrategy {
+	CONFIGURATION_FILE,
+	PROTECTED_BRANCHES
+
+}

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -61,7 +61,7 @@ public class GitLabService {
 	@ConfigProperty(name = "gitlab.api.token.approver")
 	Optional<String> apiTokenApprover;
 
-	@ConfigProperty(name = "protected.branch.merge.strategy")
+	@ConfigProperty(name = "protected.branch.merge.strategy", defaultValue = "false")
 	boolean protectedBranchMergeStrategy;
 
 	@Inject

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -28,6 +28,7 @@ import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestParams;
+import org.gitlab4j.api.models.ProtectedBranch;
 import org.gitlab4j.models.Constants.MergeRequestState;
 
 import controller.model.CascadeResult;
@@ -60,12 +61,16 @@ public class GitLabService {
 	@ConfigProperty(name = "gitlab.api.token.approver")
 	Optional<String> apiTokenApprover;
 
+	@ConfigProperty(name = "protected.branch.merge.strategy")
+	boolean protectedBranchMergeStrategy;
+
 	@Inject
 	GitInfo gitInfo;
 
 	@Inject
 	BuildInfo buildInfo;
 
+	private static final String BRANCH_SEARCH_QUERY_PARAM_TEMPLATE = "^%s$";
 	private static final String UCASCADE_CONFIGURATION_FILE = "ucascade.json";
 	private static final String UCASCADE_TAG = "[ucascade]";
 	private static final String UCASCADE_BRANCH_PATTERN_PREFIX = "^mr(\\d+)_";
@@ -207,14 +212,9 @@ public class GitLabService {
 	}
 
 	private void createAutoMr(CascadeResult result, String gitlabEventUUID, Long projectId, String prevMrSourceBranch, String sourceBranch, Long mrNumber, String mergeSha) {
-		String branchModel = getBranchModelConfigurationFile(gitlabEventUUID, projectId, mergeSha);
-		String nextMainBranch = ConfigurationUtils.getNextTargetBranch(branchModel, sourceBranch);
-
-		if (nextMainBranch != null) {
-			Branch branch = getBranch(gitlabEventUUID, projectId, nextMainBranch);
-			if (!Branch.isValid(branch)) {
-				throw new IllegalStateException(String.format("GitlabEvent: '%s' | Branch named '%s' does not exist in project '%d'. Please check the ucascade configuration file.", gitlabEventUUID, nextMainBranch, projectId));
-			}
+		Branch branch = getNextTargetBranch(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		if (branch != null) {
+			String nextMainBranch = branch.getName();
 			if (haveDiff(gitlabEventUUID, projectId, mergeSha, nextMainBranch)) {
 				String tmpBranchName = "mr" + mrNumber + "_" + sourceBranch;
 				createBranch(gitlabEventUUID, projectId, tmpBranchName, mergeSha);
@@ -567,6 +567,66 @@ public class GitLabService {
 			return new String(Base64.getDecoder().decode(encodedContent));
 		} catch (GitLabApiException e) {
 			throw new IllegalStateException(String.format("GitlabEvent: '%s' | Configuration file '%s' not found in remote repository at '%s'", gitlabEventUUID, UCASCADE_CONFIGURATION_FILE, ref), e);
+		}
+	}
+
+	private Branch getNextTargetBranch(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+		if (protectedBranchMergeStrategy) {
+			return getNextTargetBranchFromProtectedBranches(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		} else {
+			return getNextTargetBranchFromBranchModel(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		}
+	}
+
+	private Branch getNextTargetBranchFromBranchModel(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+		String branchModel = getBranchModelConfigurationFile(gitlabEventUUID, projectId, mergeSha);
+		String nextMainBranch = ConfigurationUtils.getNextTargetBranch(branchModel, sourceBranch);
+		Branch targetBranch = null;
+		if (nextMainBranch != null) {
+			targetBranch = getBranch(gitlabEventUUID, projectId, nextMainBranch);
+			if (!Branch.isValid(targetBranch)) {
+				throw new IllegalStateException(String.format("GitlabEvent: '%s' | Branch named '%s' does not exist in projectId '%d'. Please check the ucascade configuration file.", gitlabEventUUID, nextMainBranch, projectId));
+			}
+		}
+		return targetBranch;
+	}
+
+	private Branch getNextTargetBranchFromProtectedBranches(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+		try {
+			List<ProtectedBranch> protectedBranches = gitlab.getProtectedBranchesApi().getProtectedBranches(projectId);
+			boolean sourceBranchFounded = false;
+			Branch targetBranch = null;
+			boolean withWildcardRules = protectedBranches.stream().anyMatch(pb -> pb.getName().contains("*"));
+			if (withWildcardRules) {
+				outerLoop: for (ProtectedBranch protectedBranch : protectedBranches) {
+					String search = BRANCH_SEARCH_QUERY_PARAM_TEMPLATE.formatted(protectedBranch.getName());
+					List<Branch> branches = gitlab.getRepositoryApi().getBranches(projectId, search);
+					for (Branch branch : branches) {
+						if (sourceBranchFounded) {
+							targetBranch = branch;
+							break outerLoop;
+						}
+						if (branch.getName().equals(sourceBranch)) {
+							sourceBranchFounded = true;
+						}
+					}
+					sourceBranchFounded = false;
+				}
+			} else {
+				for (ProtectedBranch protectedBranch : protectedBranches) {
+					Branch branch = gitlab.getRepositoryApi().getBranch(projectId, protectedBranch.getName());
+					if (sourceBranchFounded) {
+						targetBranch = branch;
+						break;
+					}
+					if (branch.getName().equals(sourceBranch)) {
+						sourceBranchFounded = true;
+					}
+				}
+			}
+			return targetBranch;
+		} catch (GitLabApiException e) {
+			throw new IllegalStateException(String.format("GitlabEvent: '%s' | Cannot retrieve protected branch '%s'", gitlabEventUUID, sourceBranch), e);
 		}
 	}
 

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -607,6 +607,7 @@ public class GitLabService {
 					String search = BRANCH_SEARCH_QUERY_PARAM_TEMPLATE.formatted(protectedBranch.getName());
 					List<Branch> branches = gitlab.getRepositoryApi().getBranches(projectId, search);
 					List<String> sortedBranchNames = branches.stream()
+							.filter(Branch::isValid)
 							.map(Branch::getName)
 							.sorted(new AlphanumericComparator())
 							.toList();
@@ -624,12 +625,14 @@ public class GitLabService {
 			} else {
 				for (String protectedBranch : sortedProtectedBranchNames) {
 					Branch branch = gitlab.getRepositoryApi().getBranch(projectId, protectedBranch);
-					if (sourceBranchFounded) {
-						targetBranch = branch.getName();
-						break;
-					}
-					if (branch.getName().equals(sourceBranch)) {
-						sourceBranchFounded = true;
+					if (Branch.isValid(branch)) {
+						if (sourceBranchFounded) {
+							targetBranch = branch.getName();
+							break;
+						}
+						if (branch.getName().equals(sourceBranch)) {
+							sourceBranchFounded = true;
+						}
 					}
 				}
 			}

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -573,12 +573,12 @@ public class GitLabService {
 
 	private String getNextTargetBranch(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
 		return switch (mergeStrategy) {
-		case CONFIGURATION_FILE -> getNextTargetBranchFromBranchModel(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		case CONFIGURATION_FILE -> getNextTargetBranchFromConfigurationFile(gitlabEventUUID, projectId, sourceBranch, mergeSha);
 		case PROTECTED_BRANCHES -> getNextTargetBranchFromProtectedBranches(gitlabEventUUID, projectId, sourceBranch, mergeSha);
 		};
 	}
 
-	private String getNextTargetBranchFromBranchModel(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+	private String getNextTargetBranchFromConfigurationFile(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
 		String branchModel = getBranchModelConfigurationFile(gitlabEventUUID, projectId, mergeSha);
 		String nextMainBranch = ConfigurationUtils.getNextTargetBranch(branchModel, sourceBranch);
 		String targetBranch = null;

--- a/src/main/java/service/GitLabService.java
+++ b/src/main/java/service/GitLabService.java
@@ -36,12 +36,14 @@ import controller.model.DeleteBranchResult;
 import controller.model.MergeRequestResult;
 import controller.model.MergeRequestSimple;
 import controller.model.MergeRequestUcascadeState;
+import enums.MergeStrategy;
 import io.quarkus.info.BuildInfo;
 import io.quarkus.info.GitInfo;
 import io.quarkus.logging.Log;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Blocking;
 import io.vertx.mutiny.core.eventbus.EventBus;
+import se.sawano.java.text.AlphanumericComparator;
 import util.ConfigurationUtils;
 
 @ApplicationScoped
@@ -61,8 +63,8 @@ public class GitLabService {
 	@ConfigProperty(name = "gitlab.api.token.approver")
 	Optional<String> apiTokenApprover;
 
-	@ConfigProperty(name = "protected.branch.merge.strategy", defaultValue = "false")
-	boolean protectedBranchMergeStrategy;
+	@ConfigProperty(name = "merge.strategy", defaultValue = "configuration_file")
+	MergeStrategy mergeStrategy;
 
 	@Inject
 	GitInfo gitInfo;
@@ -212,9 +214,8 @@ public class GitLabService {
 	}
 
 	private void createAutoMr(CascadeResult result, String gitlabEventUUID, Long projectId, String prevMrSourceBranch, String sourceBranch, Long mrNumber, String mergeSha) {
-		Branch branch = getNextTargetBranch(gitlabEventUUID, projectId, sourceBranch, mergeSha);
-		if (branch != null) {
-			String nextMainBranch = branch.getName();
+		String nextMainBranch = getNextTargetBranch(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		if (nextMainBranch != null) {
 			if (haveDiff(gitlabEventUUID, projectId, mergeSha, nextMainBranch)) {
 				String tmpBranchName = "mr" + mrNumber + "_" + sourceBranch;
 				createBranch(gitlabEventUUID, projectId, tmpBranchName, mergeSha);
@@ -570,53 +571,61 @@ public class GitLabService {
 		}
 	}
 
-	private Branch getNextTargetBranch(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
-		if (protectedBranchMergeStrategy) {
-			return getNextTargetBranchFromProtectedBranches(gitlabEventUUID, projectId, sourceBranch, mergeSha);
-		} else {
-			return getNextTargetBranchFromBranchModel(gitlabEventUUID, projectId, sourceBranch, mergeSha);
-		}
+	private String getNextTargetBranch(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+		return switch (mergeStrategy) {
+		case CONFIGURATION_FILE -> getNextTargetBranchFromBranchModel(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		case PROTECTED_BRANCHES -> getNextTargetBranchFromProtectedBranches(gitlabEventUUID, projectId, sourceBranch, mergeSha);
+		};
 	}
 
-	private Branch getNextTargetBranchFromBranchModel(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+	private String getNextTargetBranchFromBranchModel(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
 		String branchModel = getBranchModelConfigurationFile(gitlabEventUUID, projectId, mergeSha);
 		String nextMainBranch = ConfigurationUtils.getNextTargetBranch(branchModel, sourceBranch);
-		Branch targetBranch = null;
+		String targetBranch = null;
 		if (nextMainBranch != null) {
-			targetBranch = getBranch(gitlabEventUUID, projectId, nextMainBranch);
-			if (!Branch.isValid(targetBranch)) {
+			Branch branch = getBranch(gitlabEventUUID, projectId, nextMainBranch);
+			if (!Branch.isValid(branch)) {
 				throw new IllegalStateException(String.format("GitlabEvent: '%s' | Branch named '%s' does not exist in projectId '%d'. Please check the ucascade configuration file.", gitlabEventUUID, nextMainBranch, projectId));
 			}
+			targetBranch = branch.getName();
 		}
 		return targetBranch;
 	}
 
-	private Branch getNextTargetBranchFromProtectedBranches(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
+	private String getNextTargetBranchFromProtectedBranches(String gitlabEventUUID, Long projectId, String sourceBranch, String mergeSha) {
 		try {
 			List<ProtectedBranch> protectedBranches = gitlab.getProtectedBranchesApi().getProtectedBranches(projectId);
+			List<String> sortedProtectedBranchNames = protectedBranches.stream()
+					.map(ProtectedBranch::getName)
+					.sorted(new AlphanumericComparator())
+					.toList();
 			boolean sourceBranchFounded = false;
-			Branch targetBranch = null;
+			String targetBranch = null;
 			boolean withWildcardRules = protectedBranches.stream().anyMatch(pb -> pb.getName().contains("*"));
 			if (withWildcardRules) {
 				outerLoop: for (ProtectedBranch protectedBranch : protectedBranches) {
 					String search = BRANCH_SEARCH_QUERY_PARAM_TEMPLATE.formatted(protectedBranch.getName());
 					List<Branch> branches = gitlab.getRepositoryApi().getBranches(projectId, search);
-					for (Branch branch : branches) {
+					List<String> sortedBranchNames = branches.stream()
+							.map(Branch::getName)
+							.sorted(new AlphanumericComparator())
+							.toList();
+					for (String branch : sortedBranchNames) {
 						if (sourceBranchFounded) {
 							targetBranch = branch;
 							break outerLoop;
 						}
-						if (branch.getName().equals(sourceBranch)) {
+						if (branch.equals(sourceBranch)) {
 							sourceBranchFounded = true;
 						}
 					}
 					sourceBranchFounded = false;
 				}
 			} else {
-				for (ProtectedBranch protectedBranch : protectedBranches) {
-					Branch branch = gitlab.getRepositoryApi().getBranch(projectId, protectedBranch.getName());
+				for (String protectedBranch : sortedProtectedBranchNames) {
+					Branch branch = gitlab.getRepositoryApi().getBranch(projectId, protectedBranch);
 					if (sourceBranchFounded) {
-						targetBranch = branch;
+						targetBranch = branch.getName();
 						break;
 					}
 					if (branch.getName().equals(sourceBranch)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-gitlab.host=https://vyruchai.gitlab.yandexcloud.net
-protected.branch.merge.strategy=true
+gitlab.host=https://gitlab.com
+protected.branch.merge.strategy=false
 quarkus.container-image.tag=latest
 
 quarkus.info.git.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 gitlab.host=https://gitlab.com
-
 quarkus.container-image.tag=latest
 
 quarkus.info.git.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 gitlab.host=https://gitlab.com
-protected.branch.merge.strategy=false
+
 quarkus.container-image.tag=latest
 
 quarkus.info.git.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
-gitlab.host=https://gitlab.com
+gitlab.host=https://vyruchai.gitlab.yandexcloud.net
+protected.branch.merge.strategy=true
 quarkus.container-image.tag=latest
 
 quarkus.info.git.enabled=true


### PR DESCRIPTION
Improvement enabling automatic cascading merges across all protected branches in alphabetical order. Supports protect multiple branches with wildcard rules. Allows abandoning branch model support in the configuration file.

<img width="1166" height="291" alt="image" src="https://github.com/user-attachments/assets/3263e467-9eaf-4cde-a499-fedfa0c66209" />
